### PR TITLE
use conf file from source dir if not installed

### DIFF
--- a/conjure/app.py
+++ b/conjure/app.py
@@ -222,7 +222,10 @@ def main():
         print(e)
         sys.exit(1)
 
-    global_conf = ConfigObj('/etc/conjure-up.conf')
+    global_conf_file = '/etc/conjure-up.conf'
+    if not os.path.exists(global_conf_file):
+        global_conf_file = os.path.join(os.path.dirname(sys.argv[0]), 'etc', 'conjure-up.conf')
+    global_conf = ConfigObj(global_conf_file)
 
     if spell in global_conf['curated_spells']:
         metadata = path.join('/usr/share', spell, 'metadata.json')


### PR DESCRIPTION
so it works if you install via 'python3 setup.py develop'

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>