### PR TITLE
[WIP] ui tweaks

### DIFF
--- a/conjure/controllers/clouds/gui.py
+++ b/conjure/controllers/clouds/gui.py
@@ -35,7 +35,7 @@ def render():
                      finish)
 
     app.ui.set_header(
-        title="Choose a Public Cloud",
+        title="Choose a Cloud",
         excerpt=excerpt
     )
     app.ui.set_body(view)

--- a/conjure/controllers/deploy/gui.py
+++ b/conjure/controllers/deploy/gui.py
@@ -62,5 +62,5 @@ def render():
     wv = ServiceWalkthroughView(service, this.svc_idx, n_total,
                                 app.metadata_controller, finish)
 
-    app.ui.set_subheader("Review and Configure Services")
+    app.ui.set_header("Review and Configure Applications")
     app.ui.set_body(wv)

--- a/conjure/controllers/variants/gui.py
+++ b/conjure/controllers/variants/gui.py
@@ -54,6 +54,6 @@ def render():
     app.log.debug("Rendering GUI controller for Variant")
     utils.pollinate(app.session_id, 'W001')
     app.ui.set_header(
-        title='Spells'
+        title='Please choose a spell to conjure'
     )
     app.ui.set_body(view)

--- a/conjure/ui/views/cloud.py
+++ b/conjure/ui/views/cloud.py
@@ -3,7 +3,7 @@ from urwid import (WidgetWrap, Pile,
 from ubuntui.utils import Color, Padding
 from ubuntui.widgets.hr import HR
 from ubuntui.widgets.text import Instruction
-from ubuntui.widgets.buttons import cancel_btn, menu_btn
+from ubuntui.widgets.buttons import quit_btn, menu_btn
 
 
 class CloudView(WidgetWrap):
@@ -28,7 +28,7 @@ class CloudView(WidgetWrap):
             self._w.body.focus_position = 2
 
     def _build_buttons(self):
-        cancel = cancel_btn(on_press=self.cancel)
+        cancel = quit_btn(on_press=self.cancel)
         buttons = [
             Padding.line_break(""),
             Color.button_secondary(cancel,
@@ -38,7 +38,7 @@ class CloudView(WidgetWrap):
 
     def _build_widget(self):
         total_items = [
-            Padding.center_60(Instruction("Clouds")),
+            Padding.center_60(Instruction("Choose a Cloud")),
             Padding.center_60(HR())
         ]
         for item in self.clouds:
@@ -57,7 +57,7 @@ class CloudView(WidgetWrap):
         total_items.append(
             Padding.center_60(HR()))
         total_items.append(Padding.center_20(self._build_buttons()))
-        return Filler(Pile(total_items), valign='middle')
+        return Filler(Pile(total_items), valign='top')
 
     def submit(self, result):
         self.cb(result.label)

--- a/conjure/ui/views/newcloud.py
+++ b/conjure/ui/views/newcloud.py
@@ -1,4 +1,4 @@
-from ubuntui.widgets.buttons import (confirm_btn, cancel_btn)
+from ubuntui.widgets.buttons import (confirm_btn, back_btn)
 from ubuntui.widgets.text import Instruction
 from ubuntui.utils import Color, Padding
 from ubuntui.widgets.hr import HR
@@ -19,7 +19,7 @@ class NewCloudView(WidgetWrap):
             Padding.line_break(""),
             Padding.center_20(self.buttons())
         ]
-        super().__init__(Filler(Pile(_pile), valign="middle"))
+        super().__init__(Filler(Pile(_pile), valign="top"))
 
     def _swap_focus(self):
         if self._w.body.focus_position == 2:
@@ -33,8 +33,8 @@ class NewCloudView(WidgetWrap):
         return super().keypress(size, key)
 
     def buttons(self):
-        confirm = confirm_btn(on_press=self.submit)
-        cancel = cancel_btn(on_press=self.cancel)
+        confirm = confirm_btn(on_press=self.submit, label="Add credential")
+        cancel = back_btn(on_press=self.cancel)
 
         buttons = [
             Color.button_primary(confirm, focus_map='button_primary focus'),

--- a/conjure/ui/views/service_walkthrough.py
+++ b/conjure/ui/views/service_walkthrough.py
@@ -22,7 +22,7 @@ class ServiceWalkthroughView(WidgetWrap):
         self.metadata_controller = metadata_controller
         w = self.build_widgets()
         super().__init__(w)
-        self.pile.focus_position = 7
+        self.pile.focus_position = 8
 
     def selectable(self):
         return True
@@ -42,10 +42,11 @@ class ServiceWalkthroughView(WidgetWrap):
         self.scale_edit = IntegerEditor(default=1)
         connect_signal(self.scale_edit._edit, 'change',
                        self.handle_scale_changed)
-        self.continue_button = PlainButton("Deploy and Configure Next Service",
-                                           self.do_deploy)
+        self.continue_button = PlainButton(
+            "Deploy and Configure Next Application",
+            self.do_deploy)
         self.skip_rest_button = PlainButton(
-            "Deploy all {} Remaining Services with Bundle Defaults".format(
+            "Deploy all {} Remaining Applications with Bundle Defaults".format(
                 self.n_remaining),
             self.do_skip_rest
         )
@@ -57,8 +58,9 @@ class ServiceWalkthroughView(WidgetWrap):
                                     focus_map='string_input focus'))
             ], dividechars=1
         )
-        ws = [Text("{}/{}: {}".format(self.idx+1, self.n_total,
-                                      self.service.service_name)),
+        ws = [Text("{} of {}: {}".format(self.idx+1, self.n_total,
+                                         self.service.service_name.upper())),
+              Padding.center(HR()),
               Padding.center(self.description_w, left=2),
               Padding.line_break(""),
               Padding.center(self.readme_w, left=2),
@@ -73,7 +75,7 @@ class ServiceWalkthroughView(WidgetWrap):
                                          focus_map='button_secondary focus'))]
 
         self.pile = Pile(ws)
-        return Padding.center_90(Filler(self.pile, valign="middle"))
+        return Padding.center_90(Filler(self.pile, valign="top"))
 
     def handle_info_updated(self, new_info):
         self.description_w.set_text(

--- a/conjure/ui/views/variant.py
+++ b/conjure/ui/views/variant.py
@@ -1,8 +1,7 @@
 from __future__ import unicode_literals
 from urwid import (WidgetWrap, Text, Pile,
                    Columns, Filler)
-from ubuntui.widgets.hr import HR
-from ubuntui.widgets.buttons import (cancel_btn, menu_btn)
+from ubuntui.widgets.buttons import (quit_btn, menu_btn)
 from ubuntui.utils import Color, Padding
 from ubuntui.ev import EventLoop
 from conjure.utils import pollinate
@@ -15,9 +14,7 @@ class VariantView(WidgetWrap):
         self.fname_id_map = {}
         self.current_focus = 2
         _pile = [
-            Padding.center_90(
-                Color.info_context(Text("Please choose a spell to conjure:"))),
-            Padding.center_90(HR()),
+            Padding.line_break(""),
             Padding.center_90(self.build_menuable_items()),
             Padding.line_break(""),
             Padding.center_20(self.buttons())
@@ -36,7 +33,7 @@ class VariantView(WidgetWrap):
         return super().keypress(size, key)
 
     def buttons(self):
-        cancel = cancel_btn(on_press=self.cancel)
+        cancel = quit_btn(on_press=self.cancel)
 
         buttons = [
             Color.button_secondary(cancel, focus_map='button_secondary focus')

--- a/ubuntui/anchors.py
+++ b/ubuntui/anchors.py
@@ -20,14 +20,17 @@ class Header(WidgetWrap):
         self._subheader = Text(subheader, align='center')
         widgets = []
         if self._title is not None:
-            widgets.append(Color.frame_header(Text(self._title.upper())))
+            widgets.append(Color.frame_header(Padding.line_break("")))
+            widgets.append(Color.frame_header(
+                Padding.left(Text(self._title.upper()), left=2)))
+            widgets.append(Color.frame_header(Padding.line_break("")))
         widgets.append(Color.frame_subheader(self._subheader))
         if self._excerpt is not None:
             widgets.append(Text(""))
             widgets.append(
                 Padding.center_90(
                     Text(("body", self._excerpt))))
-            widgets.append(Text(""))
+        widgets.append(Text(""))
         super().__init__(Pile(widgets))
 
     @property

--- a/ubuntui/widgets/buttons.py
+++ b/ubuntui/widgets/buttons.py
@@ -15,6 +15,8 @@ class MenuSelectButton(Button):
 
 confirm_btn = partial(PlainButton, label="Confirm", on_press=None)
 cancel_btn = partial(PlainButton, label="Cancel", on_press=None)
+back_btn = partial(PlainButton, label="Back", on_press=None)
+quit_btn = partial(PlainButton, label="Quit", on_press=None)
 done_btn = partial(PlainButton, label="Done", on_press=None)
 reset_btn = partial(PlainButton, label="Reset", on_press=None)
 menu_btn = partial(MenuSelectButton, on_press=None)


### PR DESCRIPTION
This is the PR to fix recent UI discussions. The list is incomplete build on this PR to finish them all up from referenced bug.

Fixes #51

 make continue button use action, for instance: say 'add credential'
 spell description might be more visible lower in the screen
 "Clouds" list header should say 'choose a public cloud'
 move 'clouds' list up to top like list in variants
 make 'cancel' buttons either 'back' or 'quit'
 make cancel/quit button show a dialog box giving option to kill controller
 expand header to have a gray line above to make orange more visible
 search and replace 'service' with 'application'

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>