### PR TITLE
fix keyerror if friendly-name not in metadata

### DIFF
--- a/conjure/charm.py
+++ b/conjure/charm.py
@@ -101,6 +101,7 @@ def set_metadata(bundle_path, data):
     try:
         cmd = ("charm set {} conjure:='{}'".format(bundle_path,
                                                    json.dumps(data)))
+        app.log.debug(cmd)
         run(cmd, shell=True, stdout=DEVNULL, stderr=DEVNULL)
     except CalledProcessError as e:
         app.log.warning("Could not set metadata: {}".format(e))

--- a/conjure/ui/views/variant.py
+++ b/conjure/ui/views/variant.py
@@ -46,9 +46,12 @@ class VariantView(WidgetWrap):
         cols = []
         for bundle in app.bundles:
             bundle_metadata = bundle['Meta']['bundle-metadata']
-            conjure_data = bundle['Meta']['extra-info/conjure']
-            name = conjure_data.get('friendly-name',
-                                    bundle['Meta']['id']['Name'])
+            try:
+                conjure_data = bundle['Meta']['extra-info/conjure']
+                name = conjure_data.get('friendly-name',
+                                        bundle['Meta']['id']['Name'])
+            except KeyError:
+                name = bundle['Meta']['id']['Name']
             self.fname_id_map[name] = bundle
             cols.append(
                 Columns(


### PR DESCRIPTION
If the uploaded bundle doesn't contain a friendly-name in
extra-info/conjure dont die just pull the name from the Id.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>