### PR TITLE
Load gui for single spells

### DIFF
--- a/conjure/app.py
+++ b/conjure/app.py
@@ -182,11 +182,15 @@ def main():
                       'spell-dir': spell_dir,
                       'spell': spell}
 
-    if app.fetcher != "charmstore" and not hasattr(app.argv, 'cloud'):
-        utils.error(
-            "Unable to determine cloud to deploy to, please "
-            "use the format: conjure-up {} to <cloud>".format(opts.spell))
-        sys.exit(1)
+        # Need to provide app.bundles dictionary even for single
+        # spells in the GUI
+        app.bundles = [
+            {
+                'Meta': {
+                    'extra-info/conjure': metadata
+                }
+            }
+        ]
 
     if hasattr(app.argv, 'cloud'):
         if app.fetcher != "charmstore":

--- a/conjure/controllers/clouds/gui.py
+++ b/conjure/controllers/clouds/gui.py
@@ -21,6 +21,11 @@ def finish(cloud):
         # If a cloud exists create a new model for current deployment
         app.current_model = petname.Name()
         juju.add_model(app.current_model)
+
+        # Go through the rest of the gui since we already provide a direct
+        # spell path
+        if app.fetcher != 'charmstore':
+            return controllers.use('deploy').render()
         return controllers.use('variants').render()
     return controllers.use('newcloud').render(cloud)
 

--- a/conjure/controllers/newcloud/gui.py
+++ b/conjure/controllers/newcloud/gui.py
@@ -200,14 +200,20 @@ def render(cloud):
                       "assuming LXD is configured.")
 
         __do_bootstrap()
-        return controllers.use('variants').render()
+        if app.fetcher != 'charmstore':
+            return controllers.use('deploy').render()
+        else:
+            return controllers.use('variants').render()
 
     # bootstrap if existing credentials are found for cloud
     if __do_creds_exist():
         creds = juju.get_credentials()[this.cloud]
         if len(creds.keys()) > 0:
             __do_bootstrap(list(creds.keys())[0])
-            return controllers.use('variants').render()
+            if app.fetcher != 'charmstore':
+                return controllers.use('deploy').render()
+            else:
+                return controllers.use('variants').render()
 
     # show credentials editor otherwise
     try:

--- a/conjure/ui/views/cloud.py
+++ b/conjure/ui/views/cloud.py
@@ -4,6 +4,7 @@ from ubuntui.utils import Color, Padding
 from ubuntui.widgets.hr import HR
 from ubuntui.widgets.text import Instruction
 from ubuntui.widgets.buttons import quit_btn, menu_btn
+from ubuntui.ev import EventLoop
 
 
 class CloudView(WidgetWrap):
@@ -63,4 +64,4 @@ class CloudView(WidgetWrap):
         self.cb(result.label)
 
     def cancel(self, btn):
-        self.cb(back=True)
+        EventLoop.exit(0)


### PR DESCRIPTION
If a remote path to a spell is provided provide a gui to walk
a user through configuring its application configs and deployment.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>