### PR TITLE
add steps logic, few drive by fixes

### DIFF
--- a/conjure/api/application.py
+++ b/conjure/api/application.py
@@ -1,0 +1,22 @@
+""" application api
+"""
+
+from conjure import juju
+from .models import model_status
+
+
+@juju.requires_login
+def get_workload_statuses():
+    """ gather application workload statuses from all agents
+
+    Returns:
+    List of all units status
+    """
+    apps = model_status()['Services']
+    units = []
+    for k, v in apps.items():
+        if v['Units'] is None:
+            continue
+        for a, b in v['Units'].items():
+            units.append(b['WorkloadStatus']['Status'])
+    return units

--- a/conjure/controllers/deploy/gui.py
+++ b/conjure/controllers/deploy/gui.py
@@ -32,7 +32,7 @@ def finish(service=None):
         this.svc_idx += 1
         return render()
     else:
-        return controllers.use('steps').render()
+        return controllers.use('deploystatus').render()
 
     pollinate(app.session_id, 'PC')
 

--- a/conjure/controllers/deploy/tui.py
+++ b/conjure/controllers/deploy/tui.py
@@ -11,7 +11,7 @@ def finish():
     back: if true returns to previous controller
     """
     utils.pollinate(app.session_id, 'PC')
-    controllers.use('steps').render()
+    controllers.use('deploystatus').render()
 
 
 def render():

--- a/conjure/controllers/deploystatus/common.py
+++ b/conjure/controllers/deploystatus/common.py
@@ -1,5 +1,23 @@
 from subprocess import run, PIPE
 from conjure.app_config import app
+from collections import Counter
+from conjure.api import application
+
+
+def check_statuses():
+    """ verify no errors happen and wait for services to be ready
+    """
+    statuses = application.get_workload_statuses()
+    statuses_threshold = len(statuses) / 2
+    counts = Counter(statuses)
+    if 'error' in statuses:
+        raise Exception(
+            'There is an error in one of the charms. Please consult that '
+            'charms documentation.')
+    # If more than half are active move on to the processing
+    if counts['active'] > statuses_threshold:
+        return True
+    return False
 
 
 def run_script(path):

--- a/conjure/controllers/deploystatus/tui.py
+++ b/conjure/controllers/deploystatus/tui.py
@@ -1,20 +1,17 @@
 from . import common
-from collections import deque
 from conjure import juju
 from conjure import utils
+from conjure import controllers
 from conjure.api.models import model_info
 from conjure.app_config import app
-from glob import glob
 from subprocess import CalledProcessError
 import json
 import os
 import sys
-import time
 
 
 def finish():
-    utils.info("Finished.")
-    sys.exit(0)
+    return controllers.use('steps').render()
 
 
 def render():
@@ -55,39 +52,4 @@ def render():
     except Exception as e:
         utils.error("Problem with deployment: {}".format(e))
         sys.exit(1)
-
-    # post step processing
-    steps = sorted(glob(os.path.join(bundle_scripts, '*.sh')))
-    steps_queue = deque()
-    for step in steps:
-        if "00_pre.sh" in step or "00_post-bootstrap.sh" in step:
-            app.log.debug("Skipping pre and post-bootstrap steps.")
-            continue
-
-        if os.access(step, os.X_OK):
-            steps_queue.append(step)
-
-    is_requeued = False
-    while steps_queue:
-        step = steps_queue.popleft()
-        if not is_requeued:
-            utils.info(
-                "Running: {}".format(common.parse_description(step)))
-        sh = common.run_script(step)
-        result = json.loads(sh.stdout.decode('utf8'))
-        if result['returnCode'] > 0:
-            utils.error(
-                "Failure in step: {}".format(result['message']))
-            sys.exit(1)
-        if not result['isComplete']:
-            time.sleep(5)
-            if not is_requeued:
-                utils.warning("{}, please wait".format(
-                    result['message']))
-            steps_queue.appendleft(step)
-            is_requeued = True
-            continue
-        utils.info(result['message'])
-        is_requeued = False
-        app.log.debug("post execution done: {}".format(result))
     finish()

--- a/conjure/controllers/steps/tui.py
+++ b/conjure/controllers/steps/tui.py
@@ -1,11 +1,8 @@
 from . import common
 from collections import deque
-from conjure import juju
 from conjure import utils
-from conjure.api.models import model_info
 from conjure.app_config import app
 from glob import glob
-from subprocess import CalledProcessError
 import json
 import os
 import sys
@@ -13,48 +10,15 @@ import time
 
 
 def finish():
+    # return controllers.use('summary').render()
     utils.info("Finished.")
     sys.exit(0)
 
 
 def render():
-    info = model_info(app.current_model)
-    # Set our provider type environment var so that it is
-    # exposed in future processing tasks
-    app.env['JUJU_PROVIDERTYPE'] = info['ProviderType']
-
-    bundle = os.path.join(
-        app.config['spell-dir'], 'bundle.yaml')
     bundle_scripts = os.path.join(
         app.config['spell-dir'], 'conjure/steps'
     )
-
-    pre_exec_sh = os.path.join(bundle_scripts, '00_pre.sh')
-
-    # Pre processing
-    if os.path.isfile(pre_exec_sh) \
-       and os.access(pre_exec_sh, os.X_OK):
-        utils.info("Setting up prerequisites")
-        try:
-            sh = common.run_script(pre_exec_sh)
-            if sh.returncode > 0:
-                raise Exception(
-                    "Cannot execute pre-processing script: {}".format(
-                        sh.stderr.decode('utf8')))
-            result = json.loads(sh.stdout.decode('utf8'))
-            app.log.debug("pre execution done: {}".format(result))
-        except CalledProcessError as e:
-            utils.warning(
-                "Failure in pre processor: {}".format(e))
-            sys.exit(1)
-
-    # juju deploy
-    try:
-        utils.info("Deploying charms")
-        juju.deploy(bundle)
-    except Exception as e:
-        utils.error("Problem with deployment: {}".format(e))
-        sys.exit(1)
 
     # post step processing
     steps = sorted(glob(os.path.join(bundle_scripts, '*.sh')))

--- a/conjure/ui/views/deploystatus.py
+++ b/conjure/ui/views/deploystatus.py
@@ -31,7 +31,7 @@ class DeployStatusView(WidgetWrap):
                     self.table.addColumns(
                         unit._name,
                         [
-                            ('fixed', 2, getattr(unit_w, 'Icon')),
+                            ('fixed', 3, getattr(unit_w, 'Icon')),
                             ('fixed', 20, getattr(unit_w, 'Name')),
                             ('fixed', 20, getattr(unit_w, 'AgentStatus'))
                         ]

--- a/conjure/ui/views/steps.py
+++ b/conjure/ui/views/steps.py
@@ -1,0 +1,60 @@
+from conjure.ui.widgets.step import StepWidget
+from ubuntui.utils import Padding
+from ubuntui.widgets.table import Table
+from urwid import WidgetWrap
+import random
+
+
+class StepsView(WidgetWrap):
+
+    def __init__(self, app, steps):
+        self.app = app
+        self.table = Table()
+
+        self.steps_queue = steps
+        for k, v in self.steps_queue.items():
+            self.steps_queue[k] = StepWidget(v)
+            self.table.addColumns(
+                k,
+                [
+                    ('fixed', 3, self.steps_queue[k].icon),
+                    self.steps_queue[k].title,
+                ]
+            )
+            self.table.addColumns(
+                k,
+                [
+                    ('weight', 1, Padding.left(self.steps_queue[k].result,
+                                               left=4))
+
+                ], force=True
+            )
+
+        super().__init__(Padding.center_80(self.table.render()))
+
+    def update_step_message(self, key, msg):
+        """ Updates the return results from a step
+        """
+        self.steps_queue[key].result.set_text(('info_context', msg))
+
+    def update_icon_state(self, key, result_code):
+        """ updates status icon
+
+        Arguments:
+        key: step key
+        result_code: 3 types of results, error, waiting, complete
+        """
+        if result_code == "error":
+            self.steps_queue[key].icon.set_text(
+                ("error_icon", "\N{BLACK FLAG}"))
+        elif result_code == "waiting":
+            pending_status = [("pending_icon", "\N{CIRCLED BULLET}"),
+                              ("pending_icon", "\N{CIRCLED WHITE BULLET}"),
+                              ("pending_icon", "\N{FISHEYE}")]
+            self.steps_queue[key].icon.set_text(random.choice(pending_status))
+        elif result_code == "active":
+            self.steps_queue[key].icon.set_text(("success_icon", "\u2713"))
+        else:
+            # NOTE: Should not get here, if we do make sure we account
+            # for that error type above.
+            self.steps_queue[key].icon.set_text(("error_icon", "?"))

--- a/conjure/ui/widgets/step.py
+++ b/conjure/ui/widgets/step.py
@@ -1,0 +1,14 @@
+""" Step widget, attaches properties from steps to urwid Text widgets
+"""
+
+from urwid import Text
+from conjure.controllers.steps import common
+
+
+class StepWidget:
+    def __init__(self, step):
+        self.step = step
+        self.title = Text(common.parse_title(self.step))
+        self.description = Text(common.parse_description(self.step))
+        self.result = Text('')
+        self.icon = Text(("pending_icon", "\N{HOURGLASS}"))

--- a/conjure/utils.py
+++ b/conjure/utils.py
@@ -182,7 +182,8 @@ def pollinate(session, tag):
             check_call(cmd, shell=True)
         except CalledProcessError as e:
             app.log.warning("Generating random seed failed: {}".format(e))
-    submit(do_pollinate, lambda _: None)
+    if not app.argv.debug:
+        submit(do_pollinate, lambda _: None)
 
 
 def load_global_conf():

--- a/share/hooklib/common.sh
+++ b/share/hooklib/common.sh
@@ -12,14 +12,12 @@ SCRIPTPATH=$(dirname $SCRIPT)
 # $1: logger name, ie. openstack, bigdata
 # $@: rest of log message
 debug() {
-    name=$1
-    shift 1
+    name=$CONJURE_SPELL
     logger -t "conjure-up/$name" "[DEBUG] $@"
 }
 
 info() {
-    name=$1
-    shift 1
+    name=$CONJURE_SPELL
     logger -t "conjure-up/$name" "[INFO] $@"
 }
 

--- a/ubuntui/widgets/table.py
+++ b/ubuntui/widgets/table.py
@@ -48,7 +48,7 @@ class Table:
         item: Widget to add to listbox
         use_divider: use divider for row item
         """
-        if use_divider:
+        if use_divider and len(self._rows) != 0:
             self._rows.append(HR(0, 0))
         self._rows.append(item)
 


### PR DESCRIPTION
Big addition is the steps view and controller logic.

Also added support for waiting for at least half of the applications
to be in an active state before proceeding to the steps view.

Small cosmetic fixes to both deploystatus and steps views.

Fixes #29 

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>