### PR TITLE
Give deploy done control to the bundle authors

### DIFF
--- a/conjure/controllers/clouds/common.py
+++ b/conjure/controllers/clouds/common.py
@@ -61,7 +61,7 @@ def controller_provides_ctype(cloud):
     if not juju.available():
         return None
     cloud_type = juju.get_cloud(cloud)['type']
-    for c in juju.get_controllers().keys():
+    for c in juju.get_controllers()['controllers'].keys():
         juju.switch(c)
         loaded_cloud_type = juju.get_model(juju.get_current_model())['type']
         if cloud_type == loaded_cloud_type:

--- a/conjure/controllers/deploystatus/tui.py
+++ b/conjure/controllers/deploystatus/tui.py
@@ -10,7 +10,26 @@ import os
 import sys
 
 
+this = sys.modules[__name__]
+this.bundle = os.path.join(
+    app.config['spell-dir'], 'bundle.yaml')
+this.bundle_scripts = os.path.join(
+    app.config['spell-dir'], 'conjure/steps'
+)
+
+
+def __fatal(error):
+    utils.error(error)
+    sys.exit(1)
+
+
 def finish():
+    deploy_done_sh = os.path.join(this.bundle_scripts,
+                                  '00_deploy-done.sh')
+    common.wait_for_applications(deploy_done_sh,
+                                 __fatal,
+                                 utils.info)
+
     return controllers.use('steps').render()
 
 
@@ -20,13 +39,7 @@ def render():
     # exposed in future processing tasks
     app.env['JUJU_PROVIDERTYPE'] = info['ProviderType']
 
-    bundle = os.path.join(
-        app.config['spell-dir'], 'bundle.yaml')
-    bundle_scripts = os.path.join(
-        app.config['spell-dir'], 'conjure/steps'
-    )
-
-    pre_exec_sh = os.path.join(bundle_scripts, '00_pre.sh')
+    pre_exec_sh = os.path.join(this.bundle_scripts, '00_pre.sh')
 
     # Pre processing
     if os.path.isfile(pre_exec_sh) \
@@ -48,7 +61,7 @@ def render():
     # juju deploy
     try:
         utils.info("Deploying charms")
-        juju.deploy(bundle)
+        juju.deploy(this.bundle)
     except Exception as e:
         utils.error("Problem with deployment: {}".format(e))
         sys.exit(1)

--- a/conjure/controllers/steps/gui.py
+++ b/conjure/controllers/steps/gui.py
@@ -66,8 +66,9 @@ def __post_exec(*args):
     while this.steps:
         this.current_step = this.steps.popleft()
         if "00_pre.sh" in this.current_step \
-           or "00_post-bootstrap.sh" in this.current_step:
-            app.log.debug("Skipping pre and post-bootstrap steps.")
+           or "00_post-bootstrap.sh" in this.current_step \
+           or "00_deploy-done.sh" in this.current_step:
+            app.log.debug("Skipping non steps.")
             continue
 
         if os.access(this.current_step, os.X_OK):

--- a/conjure/controllers/steps/tui.py
+++ b/conjure/controllers/steps/tui.py
@@ -24,8 +24,10 @@ def render():
     steps = sorted(glob(os.path.join(bundle_scripts, '*.sh')))
     steps_queue = deque()
     for step in steps:
-        if "00_pre.sh" in step or "00_post-bootstrap.sh" in step:
-            app.log.debug("Skipping pre and post-bootstrap steps.")
+        if "00_pre.sh" in step \
+           or "00_post-bootstrap.sh" in step \
+           or "00_deploy-done.sh" in step:
+            app.log.debug("Skipping non steps.")
             continue
 
         if os.access(step, os.X_OK):

--- a/conjure/juju.py
+++ b/conjure/juju.py
@@ -47,11 +47,10 @@ def read_config(name):
 def get_current_controller():
     """ Grabs the current default controller
     """
-    env = os.path.join(juju_path(), 'current-controller')
-    if not os.path.isfile(env):
+    try:
+        return get_controllers()['current-controller']
+    except KeyError:
         return None
-    with open(env) as fp:
-        return fp.read().strip()
 
 
 def get_controller(id):
@@ -60,8 +59,9 @@ def get_controller(id):
     Arguments:
     id: controller id
     """
-    if get_controllers() and id in get_controllers():
-        return get_controllers()[id]
+    if 'controllers' in get_controllers() \
+       and id in get_controllers()['controllers']:
+        return get_controllers()['controllers'][id]
     return None
 
 
@@ -290,7 +290,7 @@ def get_controllers():
         raise LookupError(
             "Unable to list controllers: {}".format(sh.stderr.decode('utf8')))
     env = yaml.safe_load(sh.stdout.decode('utf8'))
-    return env['controllers']
+    return env
 
 
 def get_account(controller):


### PR DESCRIPTION
We access a '00_deploy-done.sh' script now to determine if
applications are available to be processed by the processing
steps.

This gives the bundle author complete control on when to start
handling processing of applications after all services are up.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>