### PR TITLE
Add juju event queue and finish service walkthru

### DIFF
--- a/conjure/controllers/deploy/common.py
+++ b/conjure/controllers/deploy/common.py
@@ -1,0 +1,14 @@
+from operator import attrgetter
+import os
+
+from bundleplacer.bundle import Bundle
+from conjure.app_config import app
+
+
+def get_bundleinfo():
+    bundle_filename = os.path.join(app.config['spell-dir'], 'bundle.yaml')
+    bundle = Bundle(filename=bundle_filename)
+    services = sorted(bundle.services,
+                      key=attrgetter('service_name'))
+
+    return bundle_filename, bundle, services

--- a/conjure/controllers/deploy/gui.py
+++ b/conjure/controllers/deploy/gui.py
@@ -1,44 +1,66 @@
-import sys
-from operator import attrgetter
-import os.path as path
+from concurrent import futures
+from functools import partial
 
+import sys
 
 from bundleplacer.charmstore_api import MetadataController
 from bundleplacer.config import Config
-from bundleplacer.bundle import Bundle
+
 from conjure import controllers
+from conjure import juju
 from conjure.app_config import app
 from conjure.ui.views.service_walkthrough import ServiceWalkthroughView
-from conjure.utils import pollinate
+from conjure import utils
+
+from .common import get_bundleinfo
 
 this = sys.modules[__name__]
 this.bundle_filename = None
 this.bundle = None
+this.services = []
 this.svc_idx = 0
 
 
-def finish(service=None):
+def __handle_exception(tag, exc):
+    utils.pollinate(app.session_id, tag)
+    app.ui.show_exception_message(exc)
+
+
+def finish(single_service=None):
     """handles deployment
 
     Arguments:
-    service: a dict for the service that was just configured. finish
-    will deploy it and call render() again to display the next one.
 
-    if service is None, continues to next controller
+    single_service: a dict for the service that was just
+    configured. finish will schedule a deploy for it and
+    call render() again to display the next one.
+
+    if service is None, schedules deploys for all remaining services,
+    schedules relations, then continues to next controller
 
     """
-    if service:
-        # TODO do deploy of service
+    if single_service:
+        juju.deploy_service(single_service,
+                            partial(__handle_exception, "ED"))
         this.svc_idx += 1
         return render()
     else:
+        for service in this.services[this.svc_idx:]:
+            juju.deploy_service(service,
+                                partial(__handle_exception, "ED"))
+        f = juju.set_relations(this.services,
+                               partial(__handle_exception, "ED"))
+        futures.wait([f])
+
         return controllers.use('deploystatus').render()
 
-    pollinate(app.session_id, 'PC')
+    utils.pollinate(app.session_id, 'PC')
 
 
 def render():
-    this.bundle_filename = path.join(app.config['spell-dir'], 'bundle.yaml')
+
+    if not this.bundle:
+        this.bundle_filename, this.bundle, this.services = get_bundleinfo()
 
     bundleplacer_cfg = Config(
         'bundle-placer',
@@ -47,19 +69,14 @@ def render():
             'bundle_key': None,
         })
 
-    if not this.bundle:
-        this.bundle = Bundle(filename=this.bundle_filename)
-
     if not app.metadata_controller:
         app.metadata_controller = MetadataController(this.bundle,
                                                      bundleplacer_cfg)
     n_total = len(this.bundle.services)
     if this.svc_idx >= n_total:
-        finish(service=None)
-        return
-    services = sorted(this.bundle.services, key=attrgetter('service_name'))
-    service = services[this.svc_idx]
+        return finish(single_service=None)
 
+    service = this.services[this.svc_idx]
     wv = ServiceWalkthroughView(service, this.svc_idx, n_total,
                                 app.metadata_controller, finish)
 

--- a/conjure/controllers/deploy/tui.py
+++ b/conjure/controllers/deploy/tui.py
@@ -1,15 +1,37 @@
+from concurrent import futures
+import sys
+from functools import partial
+
 from conjure import controllers
 from conjure import utils
 
 from conjure.app_config import app
+from conjure import juju
+
+from .common import get_bundleinfo
+
+this = sys.modules[__name__]
+this.bundle_filename = None
+this.bundle = None
+this.services = []
+
+
+def __handle_exception(tag, exc):
+    utils.error("Error deploying services: {}".format(exc))
+    sys.exit(1)
 
 
 def finish():
     """ handles deployment
 
-    Arguments:
-    back: if true returns to previous controller
     """
+    this.bundle_filename, this.bundle, this.services = get_bundleinfo()
+
+    for service in this.services:
+        juju.deploy_service(service, partial(__handle_exception, "ED"))
+    f = juju.set_relations(this.services,
+                           partial(__handle_exception, "ED"))
+    futures.wait([f])
     utils.pollinate(app.session_id, 'PC')
     controllers.use('deploystatus').render()
 

--- a/conjure/ui/views/service_walkthrough.py
+++ b/conjure/ui/views/service_walkthrough.py
@@ -9,6 +9,7 @@ from urwid import (connect_signal, Filler, WidgetWrap, Pile,
 
 from conjure.app_config import app
 from conjure.ui.widgets.option_widget import OptionWidget
+from ubuntui.ev import EventLoop
 from ubuntui.widgets.buttons import PlainButton
 from ubuntui.widgets.input import IntegerEditor
 from ubuntui.widgets.hr import HR
@@ -88,6 +89,11 @@ class ServiceWalkthroughView(WidgetWrap):
             self.handle_readme_updated)
 
     def handle_info_updated(self, new_info):
+        EventLoop.loop.event_loop._loop.call_soon_threadsafe(
+            self._update_info_on_main_thread,
+            new_info)
+
+    def _update_info_on_main_thread(self, new_info):
         self.description_w.set_text(
             new_info["Meta"]["charm-metadata"]["Summary"])
         self._invalidate()
@@ -129,6 +135,11 @@ class ServiceWalkthroughView(WidgetWrap):
         self.service.options[opname] = value
 
     def handle_readme_updated(self, readme_text_f):
+        EventLoop.loop.event_loop._loop.call_soon_threadsafe(
+            self._update_readme_on_main_thread,
+            readme_text_f)
+
+    def _update_readme_on_main_thread(self, readme_text_f):
         rls = readme_text_f.result().splitlines()
         rls = [l for l in rls if not l.startswith("#")]
         nrls = []
@@ -160,7 +171,7 @@ class ServiceWalkthroughView(WidgetWrap):
         self.service.num_units = int(newvalstr)
 
     def do_deploy(self, arg):
-        self.callback(service=self.service)
+        self.callback(single_service=self.service)
 
     def do_skip_rest(self, arg):
-        self.callback(service=None)
+        self.callback(single_service=None)


### PR DESCRIPTION
deploys services one at a time during walkthru

adds relations after all are deployed

waits for relations before moving to deploystatus view

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>