### PR TITLE
no more pre deploy scripts, no second deploy bundle

### DIFF
--- a/conjure/controllers/deploystatus/gui.py
+++ b/conjure/controllers/deploystatus/gui.py
@@ -1,16 +1,11 @@
 from conjure.ui.views.deploystatus import DeployStatusView
 from ubuntui.ev import EventLoop
-from conjure import juju
-from functools import partial
-from conjure import async
 from conjure.app_config import app
 from conjure import utils
 from conjure import controllers
-from conjure.api.models import model_info
 from . import common
 import os.path as path
 import os
-import json
 import sys
 
 
@@ -42,87 +37,6 @@ def __handle_exception(tag, exc):
     app.ui.show_exception_message(exc)
 
 
-def __handle_pre_exception(exc):
-    """ If an exception occurs in the pre processing,
-    log it but don't die
-    """
-    utils.pollinate(app.session_id, 'E003')
-    app.ui.show_exception_message(exc)
-
-
-def __pre_exec(*args):
-    """ Executes a bundles pre processing script if exists
-    """
-    info = model_info(app.current_model)
-    # Set our provider type environment var so that it is
-    # exposed in future processing tasks
-    app.env['JUJU_PROVIDERTYPE'] = info['ProviderType']
-    app.env['CONJURE_SPELL'] = app.config['spell']
-    app.log.debug(
-        "pre_exec start: {}/provider-type:{}".format(
-            app.env['CONJURE_SPELL'],
-            app.env['JUJU_PROVIDERTYPE']))
-
-    _pre_exec_sh = path.join(this.bundle_scripts, '00_pre.sh')
-    if not path.isfile(_pre_exec_sh) \
-       or not os.access(_pre_exec_sh, os.X_OK):
-        app.log.debug(
-            "Unable to execute: {}, skipping".format(_pre_exec_sh))
-        return __deploy_bundle()
-    app.ui.set_footer('Running pre-processing tasks...')
-    if not this.pre_exec_pollinate:
-        utils.pollinate(app.session_id, 'XA')
-        this.pre_exec_pollinate = True
-
-    app.log.debug("pre_exec running {}".format(_pre_exec_sh))
-
-    try:
-        future = async.submit(partial(common.run_script,
-                                      _pre_exec_sh),
-                              partial(__handle_exception,
-                                      "E002"))
-        future.add_done_callback(__pre_exec_done)
-    except Exception as e:
-        __handle_exception("E002", e)
-
-
-def __pre_exec_done(future):
-    fr = future.result()
-    result = json.loads(fr.stdout.decode('utf8'))
-    app.log.debug("pre_exec_done: {}".format(result))
-    app.log.warning(fr.stderr.decode())
-    if result['returnCode'] > 0:
-        return __handle_pre_exception(Exception(
-            'There was an error during the pre processing phase.'))
-    __deploy_bundle()
-
-
-def __deploy_bundle():
-    """ Performs the bootstrap in between processing scripts
-    """
-    juju.switch(juju.get_current_model())
-    app.log.debug("Deploying bundle: {}".format(this.bundle))
-    app.ui.set_footer('Deploying bundle...')
-    utils.pollinate(app.session_id, 'DS')
-    future = async.submit(
-        partial(juju.deploy, this.bundle),
-        partial(__handle_exception, "ED"))
-    future.add_done_callback(__deploy_bundle_done)
-
-
-def __deploy_bundle_done(future):
-    result = future.result()
-    app.log.debug("deploy_bundle_done: {}".format(result))
-    if result.returncode > 0:
-        __handle_exception("ED", Exception(
-            'There was an error deploying the bundle: {}.'.format(
-                result.stderr.decode('utf8'))))
-        return
-    app.ui.set_footer('Deploy committed, waiting...')
-    utils.pollinate(app.session_id, 'DC')
-    finish()
-
-
 def __refresh(*args):
     this.view.refresh_nodes()
     EventLoop.set_alarm_in(1, __refresh)
@@ -142,5 +56,5 @@ def render():
             name)
     )
     app.ui.set_body(this.view)
-    EventLoop.set_alarm_in(1, __pre_exec)
     EventLoop.set_alarm_in(1, __refresh)
+    finish()

--- a/conjure/controllers/deploystatus/tui.py
+++ b/conjure/controllers/deploystatus/tui.py
@@ -2,10 +2,7 @@ from . import common
 from conjure import juju
 from conjure import utils
 from conjure import controllers
-from conjure.api.models import model_info
 from conjure.app_config import app
-from subprocess import CalledProcessError
-import json
 import os
 import sys
 
@@ -34,30 +31,6 @@ def finish():
 
 
 def render():
-    info = model_info(app.current_model)
-    # Set our provider type environment var so that it is
-    # exposed in future processing tasks
-    app.env['JUJU_PROVIDERTYPE'] = info['ProviderType']
-
-    pre_exec_sh = os.path.join(this.bundle_scripts, '00_pre.sh')
-
-    # Pre processing
-    if os.path.isfile(pre_exec_sh) \
-       and os.access(pre_exec_sh, os.X_OK):
-        utils.info("Setting up prerequisites")
-        try:
-            sh = common.run_script(pre_exec_sh)
-            if sh.returncode > 0:
-                raise Exception(
-                    "Cannot execute pre-processing script: {}".format(
-                        sh.stderr.decode('utf8')))
-            result = json.loads(sh.stdout.decode('utf8'))
-            app.log.debug("pre execution done: {}".format(result))
-        except CalledProcessError as e:
-            utils.warning(
-                "Failure in pre processor: {}".format(e))
-            sys.exit(1)
-
     # juju deploy
     try:
         utils.info("Deploying charms")

--- a/conjure/controllers/newcloud/gui.py
+++ b/conjure/controllers/newcloud/gui.py
@@ -1,21 +1,21 @@
 from . import common
-from conjure.ui.views.newcloud import NewCloudView
-from conjure.models.provider import Schema
-from conjure import utils
+from conjure import async
 from conjure import controllers
 from conjure import juju
-from conjure import async
+from conjure import utils
+from conjure.api.models import model_info
 from conjure.app_config import app
-import os.path as path
-import yaml
-import petname
-import sys
-import json
-import os
+from conjure.models.provider import Schema
+from conjure.ui.views.newcloud import NewCloudView
 from functools import partial
 from subprocess import check_output
-
 from ubuntui.ev import EventLoop
+import json
+import os
+import os.path as path
+import petname
+import sys
+import yaml
 
 this = sys.modules[__name__]
 this.cloud = None
@@ -76,8 +76,11 @@ def __do_bootstrap(credential=None):
 def __post_bootstrap_exec():
     """ Executes post-bootstrap.sh if exists
     """
-    # Set provider type for post-bootstrap
-    app.env['JUJU_PROVIDERTYPE'] = this.cloud
+    info = model_info(juju.get_current_model())
+    # Set our provider type environment var so that it is
+    # exposed in future processing tasks
+    app.env['JUJU_PROVIDERTYPE'] = info['ProviderType']
+    app.env['CONJURE_SPELL'] = app.config['spell']
 
     _post_bootstrap_sh = path.join(app.config['spell-dir'],
                                    'steps/00_post-bootstrap.sh')


### PR DESCRIPTION
The more i look at the post-bootstrap and pre-deploy scripts I
realize we really only need to run 1 script and 99 times out of 100
it's for modifying the lxd profile. So do away with pre-deploy script
and just leave 00_post-bootstrap.sh and 00_deploy-done.sh

Also remove the call to deploy_bundle since we now do this with the juju ops queue

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>