### PR TITLE
dont assume unknown means active

### DIFF
--- a/share/hooklib/common.sh
+++ b/share/hooklib/common.sh
@@ -193,7 +193,7 @@ checkUnitsForActive() {
     for i in "${services[@]}"
     do
         debug "Checking agent state of $i: $(unitStatus $i 0)"
-        if [ $(unitStatus $i 0) != "active" ] && [ $(unitStatus $i 0) != "unknown" ]; then
+        if [ $(unitStatus $i 0) != "active" ]; then
             exposeResult "$i not quite ready yet" 0 "false"
         fi
     done


### PR DESCRIPTION
this was a bad idea as all services start off as unknown so we weren't
actually waiting on the services to start properly. rather than work
around this in our code just file bugs against the charms that don't
use status-set to let us know their service is ready to go.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>