### PR TITLE
install additional deps with make install-dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VERSION := $(shell ./tools/version)
 
 .PHONY: install-dependencies
 install-dependencies:
-	sudo apt-get -yy install devscripts equivs pandoc
+	sudo apt-get -yy install devscripts equivs pandoc bsdtar charm charm-tools jq
 	sudo mk-build-deps -i -t "apt-get --no-install-recommends -y" debian/control
 
 .PHONY: uninstall-dependencies


### PR DESCRIPTION
Some of the deps used by conjure are not build dependencies
so they aren't included by default in the existing makefile
target. So we manually add them to the list of deps to install
prior to mk-build-deps.

Fixes #41

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>