### PR TITLE
Fix fetching readmes for user-scoped charms

### DIFF
--- a/conjure/ui/views/service_walkthrough.py
+++ b/conjure/ui/views/service_walkthrough.py
@@ -153,6 +153,10 @@ class ServiceWalkthroughView(WidgetWrap):
                 if rls[i+1][0] in ['-', '=']:
                     continue
             nrls.append(rls[i])
+
+        if len(nrls) == 0:
+            return
+
         if nrls[0] == '':
             nrls = nrls[1:]
         # split after two paragraphs:


### PR DESCRIPTION
Test with 'conjure-up battlemidget/ghost' -- it should correctly show the readme for the ghost charm, which is cs:~adam-stokes/ghost

Fixes #100

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>