### PR TITLE
Deploy: Use latest revno if not set

### DIFF
--- a/bundleplacer/service.py
+++ b/bundleplacer/service.py
@@ -70,7 +70,7 @@ class Service:
         }
 
     def as_deployargs(self):
-        rd = {"CharmUrl": self.charm_source,
+        rd = {"CharmUrl": self.csid.as_str(),
               "ApplicationName": self.service_name,
               "NumUnits": self.num_units,
               "Constraints": self.constraints}


### PR DESCRIPTION
If a service has no revno in its charm url, this adds a check of the
charm store info to get the latest rev for the charm, and uses that for
the deploy.

Fixes #93

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>