### PR TITLE
Fixes #129

### DIFF
--- a/conjure/controllers/deploystatus/gui.py
+++ b/conjure/controllers/deploystatus/gui.py
@@ -28,7 +28,7 @@ def __handle_exception(tag, exc):
 
 def __wait_for_applications(*args):
     deploy_done_sh = os.path.join(this.bundle_scripts,
-                                  '00_deploy-done.sh')
+                                  '00_deploy-done')
 
     future = async.submit(partial(common.wait_for_applications,
                                   deploy_done_sh,

--- a/conjure/controllers/deploystatus/tui.py
+++ b/conjure/controllers/deploystatus/tui.py
@@ -16,7 +16,7 @@ this.bundle_scripts = os.path.join(
 
 def finish():
     deploy_done_sh = os.path.join(this.bundle_scripts,
-                                  '00_deploy-done.sh')
+                                  '00_deploy-done')
 
     try:
         common.wait_for_applications(deploy_done_sh,

--- a/conjure/controllers/newcloud/gui.py
+++ b/conjure/controllers/newcloud/gui.py
@@ -67,7 +67,7 @@ def __post_bootstrap_exec():
     app.env['JUJU_PROVIDERTYPE'] = info['ProviderType']
 
     _post_bootstrap_sh = path.join(app.config['spell-dir'],
-                                   'conjure/steps/00_post-bootstrap.sh')
+                                   'conjure/steps/00_post-bootstrap')
     app.log.debug(
         'Checking for post bootstrap task: {}'.format(_post_bootstrap_sh))
     if path.isfile(_post_bootstrap_sh) \

--- a/conjure/controllers/newcloud/tui.py
+++ b/conjure/controllers/newcloud/tui.py
@@ -22,7 +22,7 @@ def do_post_bootstrap():
     app.env['JUJU_PROVIDERTYPE'] = model_info('default')['ProviderType']
 
     post_bootstrap_sh = os.path.join(app.config['spell-dir'],
-                                     'conjure/steps/00_post-bootstrap.sh')
+                                     'conjure/steps/00_post-bootstrap')
     if os.path.isfile(post_bootstrap_sh) \
        and os.access(post_bootstrap_sh, os.X_OK):
         utils.pollinate(app.session_id, 'J001')

--- a/conjure/controllers/steps/gui.py
+++ b/conjure/controllers/steps/gui.py
@@ -23,7 +23,7 @@ this.bundle_scripts = path.join(
     app.config['spell-dir'], 'conjure/steps'
 )
 this.steps = deque(sorted(glob(
-    os.path.join(this.bundle_scripts, 'step-*.sh'))))
+    os.path.join(this.bundle_scripts, 'step-*'))))
 
 this.results = OrderedDict()
 

--- a/conjure/controllers/steps/tui.py
+++ b/conjure/controllers/steps/tui.py
@@ -21,7 +21,7 @@ def finish():
     )
 
     # post step processing
-    steps = sorted(glob(os.path.join(bundle_scripts, 'step-*.sh')))
+    steps = sorted(glob(os.path.join(bundle_scripts, 'step-*')))
     common.wait_for_steps(steps, utils.info, __fatal)
 
     return controllers.use('summary').render(this.results)


### PR DESCRIPTION
Do not distinguish between a shell script vs a python script
by removing the extensions used.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>