### PR TITLE
Rework step findings

### DIFF
--- a/conjure/controllers/steps/common.py
+++ b/conjure/controllers/steps/common.py
@@ -3,6 +3,8 @@ from conjure.app_config import app
 from conjure.api.models import model_info
 import json
 import os
+from collections import deque
+from glob import glob
 
 
 def run_script(path):
@@ -19,6 +21,18 @@ def set_env(inputs):
         app.log.debug("Setting environment var: {}={}".format(
             env_key,
             app.env[env_key]))
+
+
+def get_steps(steps_dir):
+    """ Gets a list of steps that can be executed on
+
+    Arguments:
+    steps_dir: path of steps
+
+    Returns:
+    list of executable steps
+    """
+    return deque(sorted(glob(os.path.join(steps_dir, 'step-*.yaml'))))
 
 
 def do_step(step, message_cb, icon_state=None):

--- a/conjure/controllers/steps/tui.py
+++ b/conjure/controllers/steps/tui.py
@@ -1,30 +1,11 @@
-from . import common
-from conjure import utils
 from conjure import controllers
-from conjure.app_config import app
-from glob import glob
-import os
-import sys
-
-this = sys.modules[__name__]
-this.results = []
-
-
-def __fatal(error):
-    utils.error(error)
-    sys.exit(1)
 
 
 def finish():
-    bundle_scripts = os.path.join(
-        app.config['spell-dir'], 'conjure/steps'
-    )
-
-    # post step processing
-    steps = sorted(glob(os.path.join(bundle_scripts, 'step-*')))
-    common.wait_for_steps(steps, utils.info, __fatal)
-
-    return controllers.use('summary').render(this.results)
+    """ We can't really process interactive steps in headless mode. Bypass
+    for now.
+    """
+    return controllers.use('summary').render([])
 
 
 def render():


### PR DESCRIPTION
Parse steps that end with yaml and verify that a script is
found and is executable, log the error if not.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>