### PR TITLE
Improve error handling in wait script

### DIFF
--- a/conjure/controllers/deploystatus/common.py
+++ b/conjure/controllers/deploystatus/common.py
@@ -21,6 +21,11 @@ def wait_for_applications(script, msg_cb):
             count = 0
             while rerun:
                 sh = utils.run_script(script)
+                if sh.returncode != 0:
+                    app.log.error("error running {}:\n{}".format(script,
+                                                                 sh.stderr))
+                    raise Exception("Error running {}".format(script))
+
                 try:
                     result = json.loads(sh.stdout.decode('utf8'))
                 except json.decoder.JSONDecodeError as e:


### PR DESCRIPTION
Check for subprocess error before decoding json

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>