### PR TITLE
pin ws4py to version working in xenial

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ urwid
 pyyaml
 jinja2
 requests_oauthlib
-ws4py
+ws4py==0.3.4
 nose
 tox
 bson


### PR DESCRIPTION
0.3.5 has a bug: https://github.com/Lawouach/WebSocket-for-Python/issues/179

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>