### PR TITLE
Improve finding existing controller & adding model

### DIFF
--- a/conjure/controllers/clouds/common.py
+++ b/conjure/controllers/clouds/common.py
@@ -51,9 +51,8 @@ def list_clouds():
     return sorted(list(clouds))
 
 
-def controller_provides_ctype(cloud):
-    """ Returns a controller that is bootstrapped and fulfills
-    the cloud type.
+def get_controller_in_cloud(cloud):
+    """ Returns a controller that is bootstrapped on the named cloud
 
     Arguments:
     cloud: cloud to check for
@@ -61,15 +60,8 @@ def controller_provides_ctype(cloud):
     Returns:
     available controller or None if nothing available
     """
-    if not juju.available():
-        return None
-    if cloud == 'maas':
-        cloud_type = 'maas'
-    else:
-        cloud_type = juju.get_cloud(cloud)['type']
-    for c in juju.get_controllers()['controllers'].keys():
-        juju.switch(c)
-        loaded_cloud_type = juju.get_model(juju.get_current_model())['type']
-        if cloud_type == loaded_cloud_type:
-            return c
+    controllers = juju.get_controllers()['controllers'].items()    
+    for controller_name, controller in controllers:
+        if cloud == controller['cloud']:
+            return controller_name
     return None

--- a/conjure/controllers/clouds/gui.py
+++ b/conjure/controllers/clouds/gui.py
@@ -1,10 +1,22 @@
 from conjure.ui.views.cloud import CloudView
+from conjure import async
 from conjure import utils
 from conjure import controllers
 from conjure.app_config import app
 from conjure import juju
 import petname
 from . import common
+
+
+def __handle_exception(exc):
+    utils.pollinate(app.session_id, "E004")
+    app.ui.show_exception_message(exc)
+
+
+def __add_model():
+    juju.switch(app.current_controller)
+    juju.add_model(app.current_model)
+    juju.switch(app.current_model)
 
 
 def finish(cloud):
@@ -14,21 +26,22 @@ def finish(cloud):
     cloud: Cloud to create the controller/model on.
     """
     utils.pollinate(app.session_id, 'CS')
-    have_existing_controller = common.controller_provides_ctype(cloud)
-    if have_existing_controller:
-        app.current_controller = have_existing_controller
-        juju.switch(have_existing_controller)
-        # If a cloud exists create a new model for current deployment
-        app.current_model = petname.Name()
-        juju.add_model(app.current_model)
-        juju.switch(app.current_model)
+    existing_controller = common.get_controller_in_cloud(cloud)
 
-        # Go through the rest of the gui since we already provide a direct
-        # spell path
-        if app.fetcher != 'charmstore-search':
-            return controllers.use('deploy').render()
-        return controllers.use('variants').render()
-    return controllers.use('newcloud').render(cloud)
+    if existing_controller is None:
+        return controllers.use('newcloud').render(cloud)
+
+    app.current_controller = existing_controller
+    app.current_model = petname.Name()
+    async.submit(__add_model,
+                 __handle_exception,
+                 queue_name=juju.JUJU_ASYNC_QUEUE)
+
+    # Go through the rest of the gui since we already provide a direct
+    # spell path
+    if app.fetcher != 'charmstore-search':
+        return controllers.use('deploy').render()
+    return controllers.use('variants').render()
 
 
 def render():

--- a/conjure/controllers/clouds/tui.py
+++ b/conjure/controllers/clouds/tui.py
@@ -16,16 +16,18 @@ def finish():
                      "/usr/share/conjure-up/run-lxd-config",
                      back)
 
-    have_existing_controller = common.controller_provides_ctype(app.argv.cloud)
-    if have_existing_controller:
-        utils.info("Creating environment, please wait.")
-        app.current_controller = have_existing_controller
-        juju.switch(have_existing_controller)
-        app.current_model = petname.Name()
-        juju.add_model(app.current_model)
-        juju.switch(app.current_model)
-        return controllers.use('variants').render()
-    return controllers.use('newcloud').render(app.argv.cloud)
+    existing_controller = common.get_controller_in_cloud(app.argv.cloud)
+    if existing_controller is None:
+        return controllers.use('newcloud').render(app.argv.cloud)
+
+    utils.info("Creating environment, please wait.")
+    app.current_controller = existing_controller
+    juju.switch(app.current_controller)
+    app.current_model = petname.Name()
+    juju.add_model(app.current_model)
+    juju.switch(app.current_model)
+
+    return controllers.use('variants').render()
 
 
 def render():

--- a/conjure/utils.py
+++ b/conjure/utils.py
@@ -169,6 +169,7 @@ def pollinate(session, tag):
         E001 - error in post bootstrap phase
         E002 - error in post processor
         E003 - error in pre processor
+        E004 - error creating model in existing controller
 
     Arguments:
     session: randomly generated session id


### PR DESCRIPTION
## PR comments:

This is two changes that went together. I wanted to background creating a new model.
However, when testing, I would call 'destroy-model' on the current model and then try again without manually switching, this ended up bootstrapping a new controller even though the controller was already there. I looked at the controller_provides_ctype function and couldn't tell why it was comparing model types instead of just controller cloud names, since in the clouds screen we are picking cloud names, not models. It also calls switch, which calls login() (I didn't understand why it did that either), and login() fails if there is no selected model, because it tries 'juju status' to check if juju is 'available'. Juju status only works if there's a selected model.

Hopefully this change is an improvement, but I've only had time to test it on 'localhost' (LXD) clouds, so maybe the other code was there to work around issues on other clouds? Let me know!

Fixes #139.

## commit log message:

Finds existing controller even if no current model or controller is
selected. Doesn't login(), so doesn't require 'juju status' to be
working to find a controller - it won't be if no model is selected.

Backgrounds creating new model on found controller, so UI is more
responsive. It's on the juju queue, so deploys will wait for add-model
to be done.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>