### PR TITLE
Show deploystatus view immediately after deploys

### DIFF
--- a/conjure/controllers/deploy/gui.py
+++ b/conjure/controllers/deploy/gui.py
@@ -1,4 +1,3 @@
-from concurrent import futures
 from functools import partial
 
 import sys
@@ -53,9 +52,9 @@ def finish(single_service=None):
                                 app.ui.set_footer,
                                 partial(__handle_exception, "ED"))
 
-        f =juju.set_relations(this.services,
-                              app.ui.set_footer,
-                              partial(__handle_exception, "ED"))
+        f = juju.set_relations(this.services,
+                               app.ui.set_footer,
+                               partial(__handle_exception, "ED"))
 
         return controllers.use('deploystatus').render(f)
 

--- a/conjure/controllers/deploy/gui.py
+++ b/conjure/controllers/deploy/gui.py
@@ -3,6 +3,8 @@ from functools import partial
 
 import sys
 
+from ubuntui.ev import EventLoop
+
 from conjure import controllers
 from conjure import juju
 from conjure.app_config import app
@@ -17,13 +19,13 @@ this.bundle = None
 this.services = []
 this.svc_idx = 0
 this.showing_error = False
-this.deploy_futures = []
 
 
 def __handle_exception(tag, exc):
     utils.pollinate(app.session_id, tag)
     app.ui.show_exception_message(exc)
     this.showing_error = True
+    EventLoop.remove_alarms()
 
 
 def finish(single_service=None):
@@ -40,25 +42,22 @@ def finish(single_service=None):
 
     """
     if single_service:
-        f = juju.deploy_service(single_service,
-                                app.ui.set_footer,
-                                partial(__handle_exception, "ED"))
-        this.deploy_futures.append(f)
+        juju.deploy_service(single_service,
+                            app.ui.set_footer,
+                            partial(__handle_exception, "ED"))
         this.svc_idx += 1
         return render()
     else:
-        fs = [juju.deploy_service(service,
-                                  app.ui.set_footer,
-                                  partial(__handle_exception, "ED"))
-              for service in this.services[this.svc_idx:]]
-        this.deploy_futures += fs
-        futures.wait(this.deploy_futures)
-        f = juju.set_relations(this.services,
-                               app.ui.set_footer,
-                               partial(__handle_exception, "ED"))
-        futures.wait([f])
+        for service in this.services[this.svc_idx:]:
+            juju.deploy_service(service,
+                                app.ui.set_footer,
+                                partial(__handle_exception, "ED"))
 
-        return controllers.use('deploystatus').render()
+        f =juju.set_relations(this.services,
+                              app.ui.set_footer,
+                              partial(__handle_exception, "ED"))
+
+        return controllers.use('deploystatus').render(f)
 
     utils.pollinate(app.session_id, 'PC')
 

--- a/conjure/controllers/deploy/tui.py
+++ b/conjure/controllers/deploy/tui.py
@@ -1,4 +1,3 @@
-from concurrent import futures
 import sys
 from functools import partial
 

--- a/conjure/controllers/deploy/tui.py
+++ b/conjure/controllers/deploy/tui.py
@@ -30,16 +30,16 @@ def finish():
     app.metadata_controller = get_metadata_controller(this.bundle,
                                                       this.bundle_filename)
 
-    deploy_futures = [juju.deploy_service(service, utils.info,
-                                          partial(__handle_exception, "ED"))
-                      for service in this.services]
-    futures.wait(deploy_futures)
+    for service in this.services:
+        juju.deploy_service(service, utils.info,
+                            partial(__handle_exception, "ED"))
+
     f = juju.set_relations(this.services,
                            utils.info,
                            partial(__handle_exception, "ED"))
-    futures.wait([f])
+
     utils.pollinate(app.session_id, 'PC')
-    controllers.use('deploystatus').render()
+    controllers.use('deploystatus').render(f)
 
 
 def render():

--- a/conjure/controllers/deploystatus/gui.py
+++ b/conjure/controllers/deploystatus/gui.py
@@ -40,6 +40,7 @@ def __wait_for_applications(*args):
 def finish(future):
     if not future.exception():
         return controllers.use('steps').render()
+    EventLoop.remove_alarms()
 
 
 def __refresh(*args):
@@ -47,7 +48,7 @@ def __refresh(*args):
     EventLoop.set_alarm_in(1, __refresh)
 
 
-def render():
+def render(deploy_future):
     """ Render deploy status view
     """
     this.view = DeployStatusView(app)
@@ -61,5 +62,5 @@ def render():
             name)
     )
     app.ui.set_body(this.view)
-    EventLoop.set_alarm_in(1, __refresh)
-    __wait_for_applications()
+    deploy_future.add_done_callback(__refresh)
+    deploy_future.add_done_callback(__wait_for_applications)

--- a/conjure/controllers/deploystatus/tui.py
+++ b/conjure/controllers/deploystatus/tui.py
@@ -14,7 +14,10 @@ this.bundle_scripts = os.path.join(
 )
 
 
-def finish():
+def finish(future):
+    if future.exception():
+        return
+
     deploy_done_sh = os.path.join(this.bundle_scripts,
                                   '00_deploy-done')
 
@@ -28,5 +31,5 @@ def finish():
     return controllers.use('steps').render()
 
 
-def render():
-    finish()
+def render(deploy_future):
+    deploy_future.add_done_callback(finish)


### PR DESCRIPTION
Don't wait for deploy calls to finish before updating UI, improves responsiveness.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>