### PR TITLE
Fix deploy via juju api

### DIFF
--- a/conjure/juju.py
+++ b/conjure/juju.py
@@ -349,6 +349,8 @@ def deploy_service(service, msg_cb=None, exc_cb=None):
             service.service_name)
         if msg_cb:
             msg_cb("{}".format(deploy_message))
+        this.CLIENT.Client(request="AddCharm",
+                           params={"url": service.csid.as_str()})
         this.CLIENT.Application(request="Deploy",
                                 params=params)
         if msg_cb:


### PR DESCRIPTION
They deprecated the adding charm to api server before deploy and now
require this step to be handled by the user of the api. yay. This fix
allows us to deploy services again.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>