### PR TITLE
Fixes #171

### DIFF
--- a/conjure/app.py
+++ b/conjure/app.py
@@ -42,6 +42,12 @@ def parse_options(argv):
                         help='Specify HTTP proxy')
     parser.add_argument('--https-proxy', dest='https_proxy',
                         help='Specify HTTPS proxy')
+    parser.add_argument('--proxy-proxy', dest='no_proxy',
+                        help='Comma separated list of IPs to not '
+                        'filter through a proxy')
+    parser.add_argument('--bootstrap-timeout', dest='bootstrap_timeout',
+                        help='Amount of time to wait for initial environment '
+                        'creation. Useful for slower network connections.')
     parser.add_argument(
         '--version', action='version', version='%(prog)s {}'.format(VERSION))
 

--- a/conjure/juju.py
+++ b/conjure/juju.py
@@ -129,6 +129,11 @@ def bootstrap(controller, cloud, series="xenial", credential=None):
         cmd += "--config apt-http-proxy={} ".format(app.argv.apt_http_proxy)
     if app.argv.apt_https_proxy:
         cmd += "--config apt-https-proxy={} ".format(app.argv.apt_https_proxy)
+    if app.argv.no_proxy:
+        cmd += "--config no-proxy={} ".format(app.argv.no_proxy)
+    if app.argv.bootstrap_timeout:
+        cmd += "--config bootstrap-timeout={} ".format(
+            app.argv.bootstrap_timeout)
 
     cmd += "--bootstrap-series={} ".format(series)
     if cloud != "localhost":


### PR DESCRIPTION
Supports extending bootstrap timeout and additional no-proxy settings
for juju.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>