### PR TITLE
fix logname

### DIFF
--- a/conjure/app.py
+++ b/conjure/app.py
@@ -147,10 +147,7 @@ def apply_proxy():
 
 def main():
     opts = parse_options(sys.argv[1:])
-    if "/" in opts.spell:
-        spell = opts.spell.split("/")[-1]
-    else:
-        spell = opts.spell
+    spell = os.path.basename(os.path.abspath(opts.spell))
 
     # cached spell dir
     spell_dir = os.environ.get('XDG_CACHE_HOME', os.path.join(


### PR DESCRIPTION
We base our logger on spell name, normalize that spell name
from whatever remote was defined:

~conjure/openstack-novalxd -> openstack-novalxd
battlemidget/openstack-novalxd -> openstack-novalxd
/home/adam/spells/openstack-novalxd -> openstack-novalxd

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>