### PR TITLE
Fixes #174

### DIFF
--- a/conjure/controllers/deploy/tui.py
+++ b/conjure/controllers/deploy/tui.py
@@ -1,12 +1,14 @@
 import sys
+import os
+import json
 from functools import partial
 
 from conjure import controllers
 from conjure import utils
-
+from conjure.api.models import model_info
 from conjure.app_config import app
 from conjure import juju
-
+from subprocess import run, PIPE
 from .common import get_bundleinfo, get_metadata_controller
 
 
@@ -19,6 +21,32 @@ this.services = []
 def __handle_exception(tag, exc):
     utils.error("Error deploying services: {}".format(exc))
     sys.exit(1)
+
+
+def do_pre_deploy():
+    """ runs pre deploy script if exists
+    """
+    # Set provider type for post-bootstrap
+    app.env['JUJU_PROVIDERTYPE'] = model_info('default')['provider-type']
+
+    pre_deploy_sh = os.path.join(app.config['spell-dir'],
+                                 'conjure/steps/00_pre-deploy')
+    if os.path.isfile(pre_deploy_sh) \
+       and os.access(pre_deploy_sh, os.X_OK):
+        utils.pollinate(app.session_id, 'J001')
+        utils.info("Running pre deployment tasks.")
+        try:
+            sh = run(pre_deploy_sh, shell=True,
+                     stdout=PIPE,
+                     stderr=PIPE,
+                     env=app.env)
+            result = json.loads(sh.stdout.decode('utf8'))
+            utils.info("Finished pre deploy task: {}".format(
+                result['message']))
+        except Exception as e:
+            utils.warning(
+                "Failed to run pre deploy task: {}".format(e))
+            sys.exit(1)
 
 
 def finish():
@@ -42,4 +70,5 @@ def finish():
 
 
 def render():
+    do_pre_deploy()
     finish()


### PR DESCRIPTION
The reason why we removed the pre-deploy in the first place is because
we couldn't guarantee that a bootstrap was completed before attempting
to login to the api server.

Fortunately, we've recently added async queues so this renders this
issue moot and we can associate our pre deploy tasks with the same async
queue as juju bootstrap. This lets us reliably run the predeploy tasks
after a bootstrap is complete and we can successfully query required
parameters like the provider type.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>