### PR TITLE
dont fail on unknown workload status message

### DIFF
--- a/share/hooklib/juju.py
+++ b/share/hooklib/juju.py
@@ -43,7 +43,9 @@ def agent_states():
     for app_name, app_dict in juju_status['applications'].items():
         for unit_name, unit_dict in app_dict.get('units', {}).items():
             cur_state = unit_dict['workload-status']['current']
-            message = unit_dict['workload-status']['message']
+            message = unit_dict['workload-status'].get(
+                'message',
+                'Unknown workload status message')
             agent_states.append((unit_name, cur_state, message))
     return agent_states
 


### PR DESCRIPTION
Some of the charms still do not use the status-set functionality from
latest juju. This accounts for that and just returns a generic string.

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>