### PR TITLE
Add extra info to error screen

### DIFF
--- a/conjure/ui/__init__.py
+++ b/conjure/ui/__init__.py
@@ -12,10 +12,16 @@ class ConjureUI(Frame):
             pass
         elif hasattr(ex, 'errno') and ex.errno == errno.ENOENT:
             # handle oserror
-            self.frame.body = ErrorView(ex.args[1])
+            errmsg = ex.args[1]
         else:
-            self.frame.body = ErrorView(ex.args[0])
+            errmsg = ex.args[0]
 
+        errmsg += ("\n"
+                   "Review log messages at /var/log/conjure-up/combined.log "
+                   "If appropriate, please submit a bug here: "
+                   "https://bugs.launchpad.net/conjure-up/+filebug")
+
+        self.frame.body = ErrorView(errmsg)
         app.log.exception("Showing dialog for exception:")
         EventLoop.remove_alarms()
 


### PR DESCRIPTION
Includes log locations and bug-filing link.

Fixes #203.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>