### PR TITLE
allow apt update on bootstrap

### DIFF
--- a/conjure/juju.py
+++ b/conjure/juju.py
@@ -118,7 +118,6 @@ def bootstrap(controller, cloud, series="xenial", credential=None):
     cmd = "juju bootstrap {} {} --upload-tools " \
           "--config image-stream=daily ".format(
               controller, cloud)
-    cmd += "--config enable-os-refresh-update=false "
     cmd += "--config enable-os-upgrade=false "
     if app.argv.http_proxy:
         cmd += "--config http-proxy={} ".format(app.argv.http_proxy)


### PR DESCRIPTION
In some cases, an out of date index can make bootstrap hang forever
while it tries to fetch packages that no longer exist. Allow an initial
apt update to avoid this.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>