### PR TITLE
Add machines if specified in bundle

### DIFF
--- a/conjure/controllers/deploy/gui.py
+++ b/conjure/controllers/deploy/gui.py
@@ -76,6 +76,10 @@ def __pre_deploy_done(future):
         app.ui.set_footer("Pre-deploy processing done.")
 
 
+def __do_add_machines():
+    juju.add_machines([md for _, md in this.bundle.machines.items()])
+
+
 def finish(single_service=None):
     """handles deployment
 
@@ -122,8 +126,13 @@ def render():
 
     if this.showing_error:
         return
+
     if not this.bundle:
         this.bundle_filename, this.bundle, this.services = get_bundleinfo()
+
+        async.submit(__do_add_machines,
+                     partial(__handle_exception, "ED"),
+                     queue_name=juju.JUJU_ASYNC_QUEUE)
 
     if not app.metadata_controller:
         app.metadata_controller = get_metadata_controller(this.bundle,

--- a/conjure/juju.py
+++ b/conjure/juju.py
@@ -320,36 +320,26 @@ def deploy(bundle):
         raise e
 
 
-def add_machine(machine, msg_cb=None, exc_cb=None):
-    """ Add single machine to model
-
-    Arguments:
-    machine: Dictionary of machine
-       {"series": "",
-        "constraints": {},
-        "jobs": ["JobHostUnits"],
-        "parent-id": "",
-        "container-type": "",
-        "instance-id": ""}
-
-    Returns:
-    machine_response: {"machines":[{"machine":"0"}]}}
-    """
-    return add_machines([machine], msg_cb, exc_cb)
-
-
 def add_machines(machines, msg_cb=None, exc_cb=None):
-    """ Add machines to model
-
-    {"request-id":4,"type":"Client","version":1,"request":"AddMachinesV2","params":{"params":[{"series":"","constraints":{},"jobs":["JobHostUnits"],"parent-id":"","container-type":"","instance-id":"","nonce":"","hardware-characteristics":{},"addresses":null}]}}
+    """Add machines to model
 
     Arguments:
-    machines: list of dictionary machine attributes
+
+    machines: list of dictionaries of machine attributes.
+    The key 'series' is required, and 'constraints' is the only other
+    supported key
+
     """
     @requires_login
     def _add_machines_async():
-        machine_response = this.CLIENT.Client(request="AddMachines",
-                                              params={"params": machines})
+        machine_params = [{"series": m['series'],
+                           "constraints": m.get('constraints', {}),
+                           "jobs": ["JobHostUnits"]}
+                          for m in machines]
+
+        machine_response = this.CLIENT.Client(
+            request="AddMachines", params={"params": machine_params})
+
         if msg_cb:
             msg_cb("Added machines: {}".format(machine_response))
         return machine_response
@@ -406,16 +396,17 @@ def deploy_service(service, msg_cb=None, exc_cb=None):
                 pid = resource_ids['pending-ids'][idx]
                 application_to_resource_map[resource['Name']] = pid
             service.resources = application_to_resource_map
-        params = {"applications": [service.as_deployargs()]}
 
-        app.log.debug("Deploying {}: {}".format(service, params))
+        app_params = {"applications": [service.as_deployargs()]}
+
+        app.log.debug("Deploying {}: {}".format(service, app_params))
 
         deploy_message = "Deploying application: {}".format(
             service.service_name)
         if msg_cb:
             msg_cb("{}".format(deploy_message))
         this.CLIENT.Application(request="Deploy",
-                                params=params)
+                                params=app_params)
         if msg_cb:
             msg_cb("{}...done.".format(deploy_message))
 

--- a/conjure/juju.py
+++ b/conjure/juju.py
@@ -320,6 +320,45 @@ def deploy(bundle):
         raise e
 
 
+def add_machine(machine, msg_cb=None, exc_cb=None):
+    """ Add single machine to model
+
+    Arguments:
+    machine: Dictionary of machine
+       {"series": "",
+        "constraints": {},
+        "jobs": ["JobHostUnits"],
+        "parent-id": "",
+        "container-type": "",
+        "instance-id": ""}
+
+    Returns:
+    machine_response: {"machines":[{"machine":"0"}]}}
+    """
+    return add_machines([machine], msg_cb, exc_cb)
+
+
+def add_machines(machines, msg_cb=None, exc_cb=None):
+    """ Add machines to model
+
+    {"request-id":4,"type":"Client","version":1,"request":"AddMachinesV2","params":{"params":[{"series":"","constraints":{},"jobs":["JobHostUnits"],"parent-id":"","container-type":"","instance-id":"","nonce":"","hardware-characteristics":{},"addresses":null}]}}
+
+    Arguments:
+    machines: list of dictionary machine attributes
+    """
+    @requires_login
+    def _add_machines_async():
+        machine_response = this.CLIENT.Client(request="AddMachines",
+                                              params={"params": machines})
+        if msg_cb:
+            msg_cb("Added machines: {}".format(machine_response))
+        return machine_response
+
+    return async.submit(_add_machines_async,
+                        exc_cb,
+                        queue_name=JUJU_ASYNC_QUEUE)
+
+
 def deploy_service(service, msg_cb=None, exc_cb=None):
     """Juju deploy service.
 


### PR DESCRIPTION
just deploying machines with placement specs in them will not create the machines, we need to add them first.

NOTE - the author of a spell should verify that the bundle is correct using 'juju deploy bundle.yaml' first, since there are some cases where an incorrect bundle could just hang forever with no error message when deployed piece by piece in this way.

Specifically, when an application has a placement spec with a machine ID number that won't exist, like "1" for a bundle with only one machine. The single machine will be named "0".

