### PR TITLE
Handle macumba server error during add machines

### DIFF
--- a/conjure/controllers/deploy/gui.py
+++ b/conjure/controllers/deploy/gui.py
@@ -77,7 +77,8 @@ def __pre_deploy_done(future):
 
 
 def __do_add_machines():
-    juju.add_machines([md for _, md in this.bundle.machines.items()])
+    juju.add_machines([md for _, md in this.bundle.machines.items()],
+                      exc_cb=partial(__handle_exception, "ED"))
 
 
 def finish(single_service=None):

--- a/conjure/juju.py
+++ b/conjure/juju.py
@@ -336,9 +336,14 @@ def add_machines(machines, msg_cb=None, exc_cb=None):
                            "constraints": m.get('constraints', {}),
                            "jobs": ["JobHostUnits"]}
                           for m in machines]
-
-        machine_response = this.CLIENT.Client(
-            request="AddMachines", params={"params": machine_params})
+        app.log.debug(machine_params)
+        try:
+            machine_response = this.CLIENT.Client(
+                request="AddMachines", params={"params": machine_params})
+        except Exception as e:
+            if exc_cb:
+                exc_cb(e)
+            return
 
         if msg_cb:
             msg_cb("Added machines: {}".format(machine_response))

--- a/conjure/ui/__init__.py
+++ b/conjure/ui/__init__.py
@@ -3,20 +3,23 @@ from ubuntui.views import ErrorView
 from conjure import async
 from conjure.app_config import app
 from ubuntui.ev import EventLoop
+import macumba
 import errno
 
 
 class ConjureUI(Frame):
     def show_exception_message(self, ex):
+
         if isinstance(ex, async.ThreadCancelledException):
             pass
+        elif isinstance(ex, macumba.errors.ServerError):
+            errmsg = ex.args[1]
         elif hasattr(ex, 'errno') and ex.errno == errno.ENOENT:
             # handle oserror
             errmsg = ex.args[1]
         else:
             errmsg = ex.args[0]
-
-        errmsg += ("\n"
+        errmsg += ("\n\n"
                    "Review log messages at /var/log/conjure-up/combined.log "
                    "If appropriate, please submit a bug here: "
                    "https://bugs.launchpad.net/conjure-up/+filebug")


### PR DESCRIPTION
macumba.errors.ServerError is pretty common exception so
we add that to our checks in the show exception dialog.

Make use of that server error during add_machines

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>