### PR TITLE
Search for `conjure-up` rather than `conjure`

### DIFF
--- a/conjure/app.py
+++ b/conjure/app.py
@@ -222,7 +222,7 @@ def main():
 
         # Install any required packages for any of the bundles
         for bundle in app.bundles:
-            extra_info = bundle['Meta']['extra-info/conjure']
+            extra_info = bundle['Meta']['extra-info/conjure-up']
             if 'packages' in extra_info:
                 app.log.debug('Found {} to install via apt'.format(
                     extra_info['packages']))
@@ -270,7 +270,7 @@ def main():
         app.bundles = [
             {
                 'Meta': {
-                    'extra-info/conjure': metadata
+                    'extra-info/conjure-up': metadata
                 }
             }
         ]

--- a/conjure/charm.py
+++ b/conjure/charm.py
@@ -64,8 +64,8 @@ def search(tags, promulgated=True):
     """ Search charmstore by tag(s)
 
     Usage:
-    https://api.jujucharms.com/charmstore/v5/search?tags=conjure-openstack
-    &include=id&include=extra-info/conjure&type=bundle
+    https://api.jujucharms.com/charmstore/v5/search?tags=conjure-up-openstack
+    &include=id&include=extra-info/conjure-up&type=bundle
 
     Arguments:
     tags: single or list of tags to search for
@@ -74,13 +74,13 @@ def search(tags, promulgated=True):
     if not isinstance(tags, list):
         tags = [tags]
 
-    tags = ["conjure-{}".format(t) for t in tags]
+    tags = ["conjure-up-{}".format(t) for t in tags]
     query_str = "&tags=".join(tags)
     if promulgated:
         query_str += "&promulgated=1"
     query_str += "&include=bundle-metadata"
     query_str += "&include=id"
-    query_str += "&include=extra-info/conjure"
+    query_str += "&include=extra-info/conjure-up"
     query_str += "&type=bundle"
     query = path.join(cs, 'search?tags={}'.format(query_str))
     req = requests.get(query)
@@ -99,8 +99,8 @@ def set_metadata(bundle_path, data):
     data: dictionary of fields
     """
     try:
-        cmd = ("charm set {} conjure:='{}'".format(bundle_path,
-                                                   json.dumps(data)))
+        cmd = ("charm set {} conjure-up:='{}'".format(bundle_path,
+                                                      json.dumps(data)))
         app.log.debug(cmd)
         run(cmd, shell=True, stdout=DEVNULL, stderr=DEVNULL)
     except CalledProcessError as e:

--- a/conjure/controllers/clouds/common.py
+++ b/conjure/controllers/clouds/common.py
@@ -9,7 +9,7 @@ def parse_whitelist():
     for bundle in app.bundles:
         try:
             for cloud \
-                 in bundle['Meta']['extra-info/conjure']['cloud-whitelist']:
+                 in bundle['Meta']['extra-info/conjure-up']['cloud-whitelist']:
                 if cloud not in current:
                     current.append(cloud)
         except:
@@ -24,7 +24,7 @@ def parse_blacklist():
     for bundle in app.bundles:
         try:
             for cloud \
-                 in bundle['Meta']['extra-info/conjure']['cloud-blacklist']:
+                 in bundle['Meta']['extra-info/conjure-up']['cloud-blacklist']:
                 if cloud not in current:
                     current.append(cloud)
         except:

--- a/conjure/ui/views/variant.py
+++ b/conjure/ui/views/variant.py
@@ -47,7 +47,7 @@ class VariantView(WidgetWrap):
         for bundle in app.bundles:
             bundle_metadata = bundle['Meta']['bundle-metadata']
             try:
-                conjure_data = bundle['Meta']['extra-info/conjure']
+                conjure_data = bundle['Meta']['extra-info/conjure-up']
                 name = conjure_data.get('friendly-name',
                                         bundle['Meta']['id']['Name'])
             except KeyError:


### PR DESCRIPTION
Avoid any confusion and to keep naming consistent

Fixes #245 

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>