### PR TITLE
Move metadata controller init earlier

### DIFF
--- a/conjure/app.py
+++ b/conjure/app.py
@@ -12,8 +12,14 @@ from conjure.download import (download, download_local,
                               get_remote_url, fetcher)
 from conjure.log import setup_logging
 from conjure.ui import ConjureUI
+
+from bundleplacer.bundle import Bundle
+from bundleplacer.charmstore_api import MetadataController
+from bundleplacer.config import Config
+
 from ubuntui.ev import EventLoop
 from ubuntui.palette import STYLES
+
 import argparse
 import json
 import os
@@ -65,12 +71,24 @@ def unhandled_input(key):
 
 
 def _start(*args, **kwargs):
-    """ Initially load cloud selection screen
-    """
+    setup_metadata()
     if app.argv.status_only:
         controllers.use('deploystatus').render()
     else:
         controllers.use('clouds').render()
+
+
+def setup_metadata():
+    bundle_filename = os.path.join(app.config['spell-dir'], 'bundle.yaml')
+    bundle = Bundle(filename=bundle_filename)
+    bundleplacer_cfg = Config(
+        'bundle-placer',
+        {
+            'bundle_filename': bundle_filename,
+            'bundle_key': None,
+        })
+
+    app.metadata_controller = MetadataController(bundle, bundleplacer_cfg)
 
 
 def has_valid_juju():

--- a/conjure/controllers/bundlereadme/gui.py
+++ b/conjure/controllers/bundlereadme/gui.py
@@ -4,11 +4,10 @@ from conjure import controllers
 from conjure.app_config import app
 from conjure.ui.views.bundle_readme_view import BundleReadmeView
 from conjure import utils
-from conjure.controllers.deploy.common import (get_bundleinfo,
-                                               get_metadata_controller)
 
 
 class BundleReadmeController:
+
     def __init__(self):
         self.bundle_filename = None
         self.bundle = None
@@ -23,14 +22,6 @@ class BundleReadmeController:
         return controllers.use('deploy').render()
 
     def render(self):
-
-        if not self.bundle:
-            self.bundle_filename, self.bundle, self.services = get_bundleinfo()
-
-        if not app.metadata_controller:
-            app.metadata_controller = get_metadata_controller(
-                self.bundle,
-                self.bundle_filename)
         _, rows = EventLoop.screen_size()
         rows = int(rows * .75)
         brmv = BundleReadmeView(app.metadata_controller,

--- a/conjure/controllers/deploy/common.py
+++ b/conjure/controllers/deploy/common.py
@@ -2,8 +2,6 @@ from operator import attrgetter
 import os
 
 from bundleplacer.bundle import Bundle
-from bundleplacer.charmstore_api import MetadataController
-from bundleplacer.config import Config
 
 from conjure.app_config import app
 
@@ -15,14 +13,3 @@ def get_bundleinfo():
                       key=attrgetter('service_name'))
 
     return bundle_filename, bundle, services
-
-
-def get_metadata_controller(bundle, bundle_filename):
-    bundleplacer_cfg = Config(
-        'bundle-placer',
-        {
-            'bundle_filename': bundle_filename,
-            'bundle_key': None,
-        })
-
-    return MetadataController(bundle, bundleplacer_cfg)

--- a/conjure/controllers/deploy/gui.py
+++ b/conjure/controllers/deploy/gui.py
@@ -10,7 +10,7 @@ from conjure.app_config import app
 from conjure.ui.views.service_walkthrough import ServiceWalkthroughView
 from conjure import utils
 from conjure.api.models import model_info
-from .common import get_bundleinfo, get_metadata_controller
+from .common import get_bundleinfo
 
 
 class DeployController:
@@ -133,10 +133,6 @@ class DeployController:
             async.submit(self._do_add_machines,
                          partial(self._handle_exception, "ED"),
                          queue_name=juju.JUJU_ASYNC_QUEUE)
-
-        if not app.metadata_controller:
-            app.metadata_controller = get_metadata_controller(
-                self.bundle, self.bundle_filename)
 
         n_total = len(self.services)
         if self.svc_idx >= n_total:

--- a/conjure/controllers/deploy/tui.py
+++ b/conjure/controllers/deploy/tui.py
@@ -9,7 +9,6 @@ from conjure.api.models import model_info
 from conjure.app_config import app
 from conjure import juju
 from subprocess import run, PIPE
-from .common import get_bundleinfo, get_metadata_controller
 
 
 this = sys.modules[__name__]
@@ -58,10 +57,6 @@ def finish():
     """ handles deployment
 
     """
-    this.bundle_filename, this.bundle, this.services = get_bundleinfo()
-    app.metadata_controller = get_metadata_controller(this.bundle,
-                                                      this.bundle_filename)
-
     for service in this.services:
         juju.deploy_service(service, utils.info,
                             partial(__handle_exception, "ED"))


### PR DESCRIPTION
Starts loading application readmes as soon as possible.
Avoids showing 'loading readme' message on first app screen in most
cases.
Fixes #263.