### PR TITLE
load metadata after spell is chosen

### DIFF
--- a/conjure/app.py
+++ b/conjure/app.py
@@ -13,9 +13,6 @@ from conjure.download import (download, download_local,
 from conjure.log import setup_logging
 from conjure.ui import ConjureUI
 
-from bundleplacer.bundle import Bundle
-from bundleplacer.charmstore_api import MetadataController
-from bundleplacer.config import Config
 
 from ubuntui.ev import EventLoop
 from ubuntui.palette import STYLES
@@ -71,24 +68,12 @@ def unhandled_input(key):
 
 
 def _start(*args, **kwargs):
-    setup_metadata()
+    if app.fetcher != 'charmstore-search':
+        utils.setup_metadata_controller()
     if app.argv.status_only:
         controllers.use('deploystatus').render()
     else:
         controllers.use('clouds').render()
-
-
-def setup_metadata():
-    bundle_filename = os.path.join(app.config['spell-dir'], 'bundle.yaml')
-    bundle = Bundle(filename=bundle_filename)
-    bundleplacer_cfg = Config(
-        'bundle-placer',
-        {
-            'bundle_filename': bundle_filename,
-            'bundle_key': None,
-        })
-
-    app.metadata_controller = MetadataController(bundle, bundleplacer_cfg)
 
 
 def has_valid_juju():

--- a/conjure/controllers/variants/gui.py
+++ b/conjure/controllers/variants/gui.py
@@ -50,6 +50,8 @@ class VariantsController:
                       'spell-dir': spell_dir,
                       'spell': spell_name}
 
+        utils.setup_metadata_controller()
+
         return controllers.use('bundlereadme').render()
 
     def render(self):

--- a/conjure/utils.py
+++ b/conjure/utils.py
@@ -12,6 +12,10 @@ from conjure.async import submit
 from conjure.app_config import app
 from configobj import ConfigObj
 
+from bundleplacer.bundle import Bundle
+from bundleplacer.config import Config
+from bundleplacer.charmstore_api import MetadataController
+
 
 def run_script(path):
     return run(path, shell=True, stderr=PIPE, stdout=PIPE, env=app.env)
@@ -275,3 +279,16 @@ def load_global_conf():
             return yaml.safe_load(fp.read())
     except:
         return {}
+
+
+def setup_metadata_controller():
+    bundle_filename = os.path.join(app.config['spell-dir'], 'bundle.yaml')
+    bundle = Bundle(filename=bundle_filename)
+    bundleplacer_cfg = Config(
+        'bundle-placer',
+        {
+            'bundle_filename': bundle_filename,
+            'bundle_key': None,
+        })
+
+    app.metadata_controller = MetadataController(bundle, bundleplacer_cfg)


### PR DESCRIPTION
In keyword search mode, we have an app config with a bogus spell-dir, so
we need to wait until the variants view to create the metadata controller.

A simpler version of this fix would just always create it in
bundlereadme, but I'm keeping it in _start for the other case so that it
can be ready slightly sooner and avoid showing "Readme Loading" for
direct loaded spells.

Fixes #271 