### PR TITLE
Fixes #266

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,0 +1,2 @@
+Depends: tox
+Test-Command: tox -e py35


### PR DESCRIPTION
This enables autopkgtest, see
http://packaging.ubuntu.com/html/auto-pkg-test.html

To reproduce:

sudo apt-get install autopkgtest qemu-system qemu-utils
adt-buildvm-ubuntu-cloud -v
adt-run -U --unbuilt-tree . --- qemu adt-xenial-amd64-cloud.img

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>