### PR TITLE
remove superfluous async submit for add_machines

### DIFF
--- a/conjure/controllers/deploy/gui.py
+++ b/conjure/controllers/deploy/gui.py
@@ -73,10 +73,6 @@ class DeployController:
         else:
             app.ui.set_footer("Pre-deploy processing done.")
 
-    def _do_add_machines(self):
-        juju.add_machines([md for _, md in self.bundle.machines.items()],
-                          exc_cb=partial(self._handle_exception, "ED"))
-
     def finish(self, single_service=None):
         """handles deployment
 
@@ -129,10 +125,8 @@ class DeployController:
 
         if not self.bundle:
             self.bundle_filename, self.bundle, self.services = get_bundleinfo()
-
-            async.submit(self._do_add_machines,
-                         partial(self._handle_exception, "ED"),
-                         queue_name=juju.JUJU_ASYNC_QUEUE)
+            juju.add_machines([md for _, md in self.bundle.machines.items()],
+                              exc_cb=partial(self._handle_exception, "ED"))
 
         n_total = len(self.services)
         if self.svc_idx >= n_total:

--- a/conjure/controllers/deploy/tui.py
+++ b/conjure/controllers/deploy/tui.py
@@ -71,6 +71,8 @@ class DeployController:
     def render(self):
         self.bundle_filename, self.bundle, self.services = get_bundleinfo()
         self.do_pre_deploy()
+        juju.add_machines([md for _, md in self.bundle.machines.items()],
+                          exc_cb=partial(self._handle_exception, "ED"))
         self.finish()
 
 _controller_class = DeployController


### PR DESCRIPTION
Unnecessary extra async queue entry caused a bug where services could be
added before the machines they needed.

_do_add_machines just called juju.add_machines, which also enqueues a
function to do the actual adding. It was possible for the user to
quickly deploy all the services in between enqueueing _do_add_machines
and when it was actually run, making the resulting queue out of order
and failing the deployment. Removing this unnecessary layer of
abstraction makes that impossible.

Fixes #273.

Also add add_machines call to TUI path.

Fixes #208.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>